### PR TITLE
Don't show comma if no city is given

### DIFF
--- a/modules/weather/weather.js
+++ b/modules/weather/weather.js
@@ -20,7 +20,7 @@ var weather = function(dbot) {
                 'json': true
             }, function(err, response, body) {
                 if(!err && body && _.has(body, 'cod') && body.cod === 200) {
-                    event.reply('['+body.name+', '+body.sys.country+']' + ' Condition: ' + body.weather[0].description + ' | Temp: ' + Math.round(body.main.temp) + 'C/'+Math.round(body.main.temp* 9 / 5 + 32)+'F | Humidity: ' + body.main.humidity + '% | Wind Speed: ' + body.wind.speed + 'KM/H');
+                    event.reply('['+(body.name ? body.name +', ':'')+body.sys.country+']' + ' Condition: ' + body.weather[0].description + ' | Temp: ' + Math.round(body.main.temp) + 'C/'+Math.round(body.main.temp* 9 / 5 + 32)+'F | Humidity: ' + body.main.humidity + '% | Wind Speed: ' + body.wind.speed + 'KM/H');
                 } else {
                     event.reply('There is no weather in ' + city);
                 }


### PR DESCRIPTION
The OpenWeatherMap API may return weather for areas unlinked to a city, on which body.name will be undefined. This would previously show up as (for example) "[ , United Kingdom]". This simple ternary will only return a comma if it is also returning a city name.