### PR TITLE
Updated d3.js again

### DIFF
--- a/install
+++ b/install
@@ -24,7 +24,7 @@ rm bootstrap-3.3.2-dist.zip
 
 mkdir d3
 cd d3
-wget https://github.com/mbostock/d3/releases/download/v3.5.3/d3.zip
+wget https://github.com/mbostock/d3/releases/download/v3.5.5/d3.zip
 unzip d3.zip
 rm d3.zip
 


### PR DESCRIPTION
Updated d3.js again. I did consider getting the install script to use the latest one automatically, but decided against it. Why?
1. It may be that a new version of bootstrap or d3js used in dbot could break a module, or the whole script.
2. Checking manually that updated libraries will still work with dbot is good practice imho, if they don't work, then a stable version can be used for the time being.

This should work, up to you @reality.