### PR TITLE
Produce uniformly-distributed permutation in ~jimble

### DIFF
--- a/modules/words/words.js
+++ b/modules/words/words.js
@@ -102,11 +102,20 @@ var words = function(dbot) {
                 }
             });
         },
-        
-        '~jimble': function(event) { 
-            event.reply(event.params[1].split('').sort(function() { 
-                return (Math.round(Math.random()) - 0.5);
-            }).join(''));  
+
+        '~jimble': function(event) {
+            var word = event.params[1].split('');
+            var used = [];
+            var jimbled = new Array(word.length);
+            for (var i = 0; i < word.length; i++) {
+                do {
+                    rnd = Math.floor(Math.random()*word.length);
+                } while (used.indexOf(rnd) != -1);
+
+                jimbled[i] = word[rnd];
+                used.push(rnd);
+            }
+            event.reply(jimbled.join(''));
         },
 
         '~merge': function(event) {


### PR DESCRIPTION
The current implementation of ~jimble uses a sorting function with a random comparison function. This does not create a uniform distribution of permutations when used with many (including the default) sorting algorithms.

This patch produces a uniformly-distributed permutation of the word by choosing a random, unused letter from the original word for each position in the jimbled word.