### PR TITLE
Use vm2 instead of sandbox library

### DIFF
--- a/install
+++ b/install
@@ -14,7 +14,7 @@ if [[ $? -gt 0 ]]; then
     exit 1
 fi
 
-npm install googlemaps humanize feedparser node-units tvdb method-override 500px process async wordnik node-uuid underscore request request-promise-native sandbox express moment-timezone moment jade databank databank-redis ent passport passport-local password-hash connect-flash 
+npm install googlemaps humanize feedparser node-units tvdb method-override 500px process async wordnik node-uuid underscore request request-promise-native vm2 express moment-timezone moment jade databank databank-redis ent passport passport-local password-hash connect-flash 
 
 cd public/
 wget https://github.com/twbs/bootstrap/releases/download/v3.3.2/bootstrap-3.3.2-dist.zip

--- a/modules/js/js.js
+++ b/modules/js/js.js
@@ -4,18 +4,15 @@
  * the channel. Also allows admins to run un-sandboxed Javascript code with
  * access to the DepressionBot instance memory.
  */
-var vm = require('vm');
-var sbox = require('sandbox');
+var VM = require('vm2').VM;
 
 var js = function(dbot) {
     var commands = {
         // Run JS code sandboxed, return result to channel.
         '~js': function(event) {
             try {
-                var s = new sbox();
-                s.run(event.input[1], function(output) {
-                    event.reply(output.result);
-                }.bind(this));
+                var s = new VM({timeout: 1000, sandbox: {}});
+                event.reply(s.run(code));
             } catch(err) {}
         },
 


### PR DESCRIPTION
See https://github.com/gf3/sandbox/issues/50 for the motivation. vm2 appears to receive regular updates whenever a sandbox escape has been found.