### PR TITLE
GitHub no longer supports git://, switch to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "jsbot"]
     path = jsbot
-    url = git://github.com/reality/jsbot.git
+    url = https://github.com/reality/jsbot.git
 [submodule "modules/github"]
     path = modules/github
-    url = git://github.com/zuzak/dbot-github.git
+    url = https://github.com/zuzak/dbot-github.git


### PR DESCRIPTION
This fixes the broken submodule cloning process, generally called by the
`install` script, which is also used by my Dockerfile

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>